### PR TITLE
Fix pack_format for 1.18.2

### DIFF
--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 8,
+    "pack_format": 9,
     "description": "§6§kgmc§r §6Made by §3osfanbuff63§r §kgmc"
   }
 }


### PR DESCRIPTION
Minecraft 1.18.2 (releasing soon-ish) is going to update pack_format to 9. This can't be tested on anything but the latest prerelease, and I don't feel like loading it. However, that's the only change. 

Fixes #11.

- [x] Included tests