### PR TITLE
Revert "Fix pack_format for 1.18.2"

### DIFF
--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 9,
+    "pack_format": 8,
     "description": "§6§kgmc§r §6Made by §3osfanbuff63§r §kgmc"
   }
 }


### PR DESCRIPTION
Reverts osfanmuffin/muffinhunt-datapack#9

This is a temporary revert, since we are waiting on OptiFabric (and OptiFine for that matter) in addition to Paper to update our servers. 