### PR TITLE
Fix and optimize the PackSquash workflow

### DIFF
--- a/.github/workflows/packsquash.yml
+++ b/.github/workflows/packsquash.yml
@@ -5,12 +5,6 @@ jobs:
     name: Optimize datapack
     runs-on: ubuntu-latest
     steps:
-     - name: Checkout repo
-       uses: actions/checkout@v3
-     - name: Setup Node.js  
-       uses: actions/setup-node@v3.0.0
-       with:
-         node-version: '>=16.14.0'
      - name: Clone repository
        uses: actions/checkout@v3
        with:
@@ -24,5 +18,3 @@ jobs:
           validate_pack_metadata_file: true
           allow_optifine_mod: true
           delete_bloat_json_keys: true
-          
-          


### PR DESCRIPTION
## Purpose
I was taking at look at [the public repositories that depend on the PackSquash GitHub action](https://github.com/ComunidadAylas/PackSquash-action/network/dependents?package_id=UGFja2FnZS0yOTYyMDA3OTkw) because, as one of its developers, I wanted to gauge how it is being used and how it may be improved. I'm always listening for feedback, but not everyone gives it, and sometimes it's better to see how a software is being used in the wild for oneself! :smile:

This repository is on that dependents list, and it looked interesting, so I read its PackSquash GitHub actions workflow. I noticed that it checked out the repository twice, which is not necessary to do, and it also installed Node, which is also not needed.

In addition, the PackSquash action sometimes failed the "Restoring cached data" step non-critically due to the branch name not being resolved correctly (i.e., being `heads/master` instead of `master`). An example of run that has this failure is https://github.com/osfanmuffin/muffinhunt-datapack/runs/5665866422. I'm not sure what causes the branch name to be wrong, though. I've committed a change in the action to the command used to get the branch name, and made a failure in this step output a warning, which may help pinning this down further. A failure restoring the cached data means that PackSquash won't get to reuse the ZIP file generated in the previous run, which is not great, but it works anyway, just slower. Let me know if you'd be interested in debugging this issue further!

## Approach
I've just removed the unnecessary steps in the workflow, as described. The PackSquash action failure to download the previous ZIP sometimes was interesting for me, and might be interesting for you too, but right now I don't think it's actionable by this repository in any form.

## Future work
None.

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/osfanbuff63/muffinhunt-datapack/blob/master/README.md) and/or [docs folder](/docs)
- [ ] Tested in the latest version of Minecraft