### PR TITLE
Add nether fortress loot tables

### DIFF
--- a/data/minecraft/loot_tables/chests/nether_bridge.json
+++ b/data/minecraft/loot_tables/chests/nether_bridge.json
@@ -1,0 +1,117 @@
+{
+    "pools": [
+      {
+        "rolls": 3,
+        "bonus_rolls": 1,
+        "entries": [
+          {
+            "type": "minecraft:item",
+            "weight": 5,
+            "name": "minecraft:coal",
+            "functions": [
+              {
+                "function": "minecraft:set_count",
+                "count": 5
+              }
+            ]
+          },
+          {
+            "type": "minecraft:item",
+            "weight": 1,
+            "name": "minecraft:netherite_ingot",
+            "functions": [
+              {
+                "function": "minecraft:set_count",
+                "count": 1
+              }
+            ]
+          },
+          {
+            "type": "minecraft:item",
+            "weight": 3,
+            "name": "minecraft:ancient_debris",
+            "functions": [
+              {
+                "function": "minecraft:set_count",
+                "count": 1
+              }
+            ]
+          },
+          {
+            "type": "minecraft:item",
+            "weight": 4,
+            "name": "minecraft:gold_ingot",
+            "functions": [
+              {
+                "function": "minecraft:set_count",
+                "count": 1
+              }
+            ]
+          },
+          {
+            "type": "minecraft:item",
+            "weight": 4,
+            "name": "minecraft:iron_ingot",
+            "functions": [
+              {
+                "function": "minecraft:set_count",
+                "count": 1
+              }
+            ]
+          },
+          {
+            "type": "minecraft:item",
+            "weight": 3,
+            "name": "minecraft:iron_pickaxe",
+            "functions": [
+              {
+                "function": "minecraft:set_count",
+                "count": 1
+              },
+              {
+                "function": "minecraft:enchant_randomly",
+                "conditions": [
+                  {
+                    "condition": "minecraft:random_chance",
+                    "chance": 0.5
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "minecraft:item",
+            "weight": 2,
+            "name": "minecraft:diamond",
+            "functions": [
+              {
+                "function": "minecraft:set_count",
+                "count": 1
+              }
+            ]
+          },
+          {
+            "type": "minecraft:item",
+            "weight": 1,
+            "name": "minecraft:diamond_helmet",
+            "functions": [
+              {
+                "function": "minecraft:set_count",
+                "count": 1
+              },
+              {
+                "function": "minecraft:enchant_randomly",
+                "conditions": [
+                  {
+                    "condition": "minecraft:random_chance",
+                    "chance": 0.05
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/data/minecraft/loot_tables/chests/nether_bridge.json
+++ b/data/minecraft/loot_tables/chests/nether_bridge.json
@@ -7,13 +7,7 @@
           {
             "type": "minecraft:item",
             "weight": 5,
-            "name": "minecraft:coal",
-            "functions": [
-              {
-                "function": "minecraft:set_count",
-                "count": 5
-              }
-            ]
+            "name": "minecraft:coal"
           },
           {
             "type": "minecraft:item",
@@ -29,35 +23,17 @@
           {
             "type": "minecraft:item",
             "weight": 3,
-            "name": "minecraft:ancient_debris",
-            "functions": [
-              {
-                "function": "minecraft:set_count",
-                "count": 1
-              }
-            ]
+            "name": "minecraft:ancient_debris"
           },
           {
             "type": "minecraft:item",
             "weight": 4,
-            "name": "minecraft:gold_ingot",
-            "functions": [
-              {
-                "function": "minecraft:set_count",
-                "count": 1
-              }
-            ]
+            "name": "minecraft:gold_ingot"
           },
           {
             "type": "minecraft:item",
             "weight": 4,
-            "name": "minecraft:iron_ingot",
-            "functions": [
-              {
-                "function": "minecraft:set_count",
-                "count": 1
-              }
-            ]
+            "name": "minecraft:iron_ingot"
           },
           {
             "type": "minecraft:item",

--- a/data/minecraft/loot_tables/chests/nether_bridge.json
+++ b/data/minecraft/loot_tables/chests/nether_bridge.json
@@ -1,7 +1,7 @@
 {
     "pools": [
       {
-        "rolls": 3,
+        "rolls": 5,
         "bonus_rolls": 1,
         "entries": [
           {
@@ -13,6 +13,12 @@
             "type": "minecraft:item",
             "weight": 1,
             "name": "minecraft:netherite_ingot",
+            "conditions": [
+               {
+                "condition": "minecraft:random_chance",
+                "chance": 0.5
+               }
+            ],
             "functions": [
               {
                 "function": "minecraft:set_count",

--- a/data/muffinhunt/functions/surface_overworld.mcfunction
+++ b/data/muffinhunt/functions/surface_overworld.mcfunction
@@ -6,4 +6,4 @@ item replace entity @a[team=dragon_ender] weapon.offhand with shield{Damage:73}
 item replace entity @a[team=juggernaut] armor.feet with diamond_boots{Unbreakable:1,display:{Name:'[{"text":"Copper Boots","color":"#FFA500","italic":"false"}]'}}	
 item replace entity @a[team=juggernaut] container.0 with diamond_sword{Unbreakable:1,display:{Name:'[{"text":"Copper Sword","color":"#FFA500","italic":"false"}]'}}
 tag @a[tag=muffinhunt] add muffinhunt_surface_overworld
-tellraw @a ["",{"text":"Surface Overworld ","color":"green"},{"text":"items given! ","color":"gold"}]
+tellraw @a [{"text":"Surface Overworld ","color":"green"},{"text":"items given! ","color":"gold"}]


### PR DESCRIPTION
## Purpose
Add nether fortress loot tables

## Approach
Add a file to override the vanilla one

## Future work
None.

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/osfanbuff63/muffinhunt-datapack/blob/master/README.md) and/or [docs folder](/docs)
- [ ] Tested in the latest version of Minecraft


