### PR TITLE
Add end mobs

### DIFF
--- a/data/minecraft/tags/functions/tick.json
+++ b/data/minecraft/tags/functions/tick.json
@@ -1,5 +1,5 @@
 {
 	"values": [
-		"muffinhunt-dev:check_trigger","muffinhunt-dev:check_lifes","muffinhunt-dev:juggernaut_repeating"
+		"muffinhunt-dev:check_trigger","muffinhunt-dev:check_lifes","muffinhunt-dev:juggernaut_repeating","muffinhunt-dev:check_end_crystals"
 	]
 }

--- a/data/muffinhunt-dev/functions/add_crystal_bossbar.mcfunction
+++ b/data/muffinhunt-dev/functions/add_crystal_bossbar.mcfunction
@@ -1,0 +1,10 @@
+team add endCrystalBossbar "End Crystals"
+execute in minecraft:muffinhunt_the_end positioned 0 100 0 as @e[type=end_crystal,distance=..350] run team join endCrystalBossbar @s 
+scoreboard objectives add EndCrystalBossbar dummy
+bossbar add end_crystal_bossbar "End Crystals"
+bossbar set end_crystal_bossbar color purple
+bossbar set end_crystal_bossbar visible true
+execute store result score EndCrystalBossbarMax EndCrystalBossbar run team list end_crystal_bossbar
+execute store result bossbar end_crystal_bossbar max run scoreboard players get EndCrystalBossbarMax EndCrystalBossbar
+scoreboard players set EndCrysBossMin EndCrystalBossbar 0
+scoreboard players set EndCrysToggle EndCrystalBossbar 1

--- a/data/muffinhunt-dev/functions/add_crystal_bossbar.mcfunction
+++ b/data/muffinhunt-dev/functions/add_crystal_bossbar.mcfunction
@@ -4,7 +4,7 @@ scoreboard objectives add EndCrystalBossbar dummy
 bossbar add end_crystal_bossbar "End Crystals"
 bossbar set end_crystal_bossbar color purple
 bossbar set end_crystal_bossbar visible true
-execute store result score EndCrystalBossbarMax EndCrystalBossbar run team list end_crystal_bossbar
+execute store result score EndCrystalBossbarMax EndCrystalBossbar run team list endCrystalBossbar
 execute store result bossbar end_crystal_bossbar max run scoreboard players get EndCrystalBossbarMax EndCrystalBossbar
 scoreboard players set EndCrysBossMin EndCrystalBossbar 0
 scoreboard players set EndCrysToggle EndCrystalBossbar 1

--- a/data/muffinhunt-dev/functions/add_crystal_bossbar.mcfunction
+++ b/data/muffinhunt-dev/functions/add_crystal_bossbar.mcfunction
@@ -8,3 +8,4 @@ execute store result score EndCrystalBossbarMax EndCrystalBossbar run team list 
 execute store result bossbar end_crystal_bossbar max run scoreboard players get EndCrystalBossbarMax EndCrystalBossbar
 scoreboard players set EndCrysBossMin EndCrystalBossbar 0
 scoreboard players set EndCrysToggle EndCrystalBossbar 1
+execute as @a[tag=muffinhunt] run bossbar set end_crystal_bossbar players @s

--- a/data/muffinhunt-dev/functions/add_enderdragon_health.mcfunction
+++ b/data/muffinhunt-dev/functions/add_enderdragon_health.mcfunction
@@ -1,0 +1,3 @@
+scoreboard objectives add EnderDragonHealth health
+execute store result score EnderDragonHealth EnderDragonHealth as @e[type=ender_dragon,limit=1] run scoreboard players get @s EnderDragonHealth
+scoreboard players set EnderDragonHalfHealth EnderDragonHealth 100

--- a/data/muffinhunt-dev/functions/check_end_crystals.mcfunction
+++ b/data/muffinhunt-dev/functions/check_end_crystals.mcfunction
@@ -1,0 +1,4 @@
+execute if score EndCrysToggle EndCrystalBossbar matches 1 as @a[tag=muffinhunt] run bossbar set end_crystal_bossbar players @s
+execute store result score EndCrystalBossbar EndCrystalBossbar run team list end_crystal_bossbar
+execute store result bossbar end_crystal_bossbar value run scoreboard players get EndCrystalBossbar EndCrystalBossbar
+execute if score EndCrystalBossbar EndCrystalBossbar <= EndCrysBossMin EndCrystalBossbar run function muffinhunt-dev:remove_bossbar

--- a/data/muffinhunt-dev/functions/check_end_crystals.mcfunction
+++ b/data/muffinhunt-dev/functions/check_end_crystals.mcfunction
@@ -1,4 +1,4 @@
 execute if score EndCrysToggle EndCrystalBossbar matches 1 as @a[tag=muffinhunt] run bossbar set end_crystal_bossbar players @s
-execute store result score EndCrystalBossbar EndCrystalBossbar run team list end_crystal_bossbar
+execute store result score EndCrystalBossbar EndCrystalBossbar run team list endCrystalBossbar
 execute store result bossbar end_crystal_bossbar value run scoreboard players get EndCrystalBossbar EndCrystalBossbar
 execute if score EndCrystalBossbar EndCrystalBossbar <= EndCrysBossMin EndCrystalBossbar run function muffinhunt-dev:remove_bossbar

--- a/data/muffinhunt-dev/functions/check_enderdragon_health.mcfunction
+++ b/data/muffinhunt-dev/functions/check_enderdragon_health.mcfunction
@@ -1,2 +1,3 @@
 execute store result score EnderDragonHealth EnderDragonHealth as @e[type=ender_dragon,limit=1] run scoreboard players get @s EnderDragonHealth
 execute if score EnderDragonHealth EnderDragonHealth = EnderDragonHalfHealth EnderDragonHealth in minecraft:muffinhunt_the_end positioned 0 50 0 run function muffinhunt-dev:dragon_half_health
+execute if score EndCrystalBossbar EndCrystalBossbar <= EndCrystalBossbarMin EndCrystalBossbar run function muffinhunt-dev:end_crystals_removed

--- a/data/muffinhunt-dev/functions/check_enderdragon_health.mcfunction
+++ b/data/muffinhunt-dev/functions/check_enderdragon_health.mcfunction
@@ -1,0 +1,2 @@
+execute store result score EnderDragonHealth EnderDragonHealth as @e[type=ender_dragon,limit=1] run scoreboard players get @s EnderDragonHealth
+execute if score EnderDragonHealth EnderDragonHealth = EnderDragonHalfHealth EnderDragonHealth in minecraft:muffinhunt_the_end positioned 0 50 0 run function muffinhunt-dev:dragon_half_health

--- a/data/muffinhunt-dev/functions/check_enderdragon_health.mcfunction
+++ b/data/muffinhunt-dev/functions/check_enderdragon_health.mcfunction
@@ -1,3 +1,3 @@
 execute store result score EnderDragonHealth EnderDragonHealth as @e[type=ender_dragon,limit=1] run scoreboard players get @s EnderDragonHealth
-execute if score EnderDragonHealth EnderDragonHealth = EnderDragonHalfHealth EnderDragonHealth in minecraft:muffinhunt_the_end positioned 0 50 0 run function muffinhunt-dev:dragon_half_health
-execute if score EndCrystalBossbar EndCrystalBossbar <= EndCrystalBossbarMin EndCrystalBossbar run function muffinhunt-dev:end_crystals_removed
+execute if score EnderDragonHealth EnderDragonHealth <= EnderDragonHalfHealth EnderDragonHealth unless score EnderDragonHealthCheck EnderDragonHealth matches 1 run function muffinhunt-dev:dragon_half_health
+execute if score EndCrystalBossbar EndCrystalBossbar <= EndCrysBossMin EndCrystalBossbar run function muffinhunt-dev:end_crystals_removed

--- a/data/muffinhunt-dev/functions/dragon_half_health.mcfunction
+++ b/data/muffinhunt-dev/functions/dragon_half_health.mcfunction
@@ -1,8 +1,7 @@
-execute in muffinhunt_the_end positioned 0 50 0 run summon armor_stand ~ ~ ~ {Invisible:1,Marker:1,Tags:["DragonMidStand"]}
 execute at @e[type=armor_stand,tag=DragonMidStand] run summon hoglin ~ ~ ~ {IsImmuneToZombification:1,ActiveEffects:[{Id:28,Duration:10000,ShowParticles:false}]}
 execute at @e[type=armor_stand,tag=DragonMidStand] run summon hoglin ~ ~ ~ {IsImmuneToZombification:1,ActiveEffects:[{Id:28,Duration:10000,ShowParticles:false}]}
 execute at @e[type=armor_stand,tag=DragonMidStand] run summon hoglin ~ ~ ~ {IsImmuneToZombification:1,ActiveEffects:[{Id:28,Duration:10000,ShowParticles:false}]}
 execute at @e[type=armor_stand,tag=DragonMidStand] run summon hoglin ~ ~ ~ {IsImmuneToZombification:1,ActiveEffects:[{Id:28,Duration:10000,ShowParticles:false}]}
 execute at @e[type=armor_stand,tag=DragonMidStand] run summon hoglin ~ ~ ~ {IsImmuneToZombification:1,ActiveEffects:[{Id:28,Duration:10000,ShowParticles:false}]}
-execute at @e[type=armor_stand,tag=DragonMidStand] as @e[type=hoglin,distance=..10] run spreadplayers ~ ~ 15 35 false @s
+execute at @e[type=armor_stand,tag=DragonMidStand] as @e[type=hoglin,distance=..10] at @s run spreadplayers ~ ~ 15 35 false @s
 tellraw @a[tag=muffinhunt] [{"text": "The ","color": "gold"},{"text": "Ender Dragon ","color": "dark_purple"},{"text": "is at half health! A surprise is in order...","color": "gold"}]

--- a/data/muffinhunt-dev/functions/dragon_half_health.mcfunction
+++ b/data/muffinhunt-dev/functions/dragon_half_health.mcfunction
@@ -1,0 +1,8 @@
+execute in muffinhunt_the_end positioned 0 50 0 run summon armor_stand ~ ~ ~ {Invisible:1,Marker:1,Tags:["DragonMidStand"]}
+execute at @e[type=armor_stand,tag=DragonMidStand] run summon hoglin ~ ~ ~ {IsImmuneToZombification:1,ActiveEffects:[{Id:28,Duration:10000,ShowParticles:false}]}
+execute at @e[type=armor_stand,tag=DragonMidStand] run summon hoglin ~ ~ ~ {IsImmuneToZombification:1,ActiveEffects:[{Id:28,Duration:10000,ShowParticles:false}]}
+execute at @e[type=armor_stand,tag=DragonMidStand] run summon hoglin ~ ~ ~ {IsImmuneToZombification:1,ActiveEffects:[{Id:28,Duration:10000,ShowParticles:false}]}
+execute at @e[type=armor_stand,tag=DragonMidStand] run summon hoglin ~ ~ ~ {IsImmuneToZombification:1,ActiveEffects:[{Id:28,Duration:10000,ShowParticles:false}]}
+execute at @e[type=armor_stand,tag=DragonMidStand] run summon hoglin ~ ~ ~ {IsImmuneToZombification:1,ActiveEffects:[{Id:28,Duration:10000,ShowParticles:false}]}
+execute at @e[type=armor_stand,tag=DragonMidStand] as @e[type=hoglin,distance=..10] run spreadplayers ~ ~ 15 35 false @s
+tellraw @a[tag=muffinhunt] [{"text": "The ","color": "gold"},{"text": "Ender Dragon ","color": "dark_purple"},{"text": "is at half health! A surprise is in order...","color": "gold"}]

--- a/data/muffinhunt-dev/functions/dragon_half_health.mcfunction
+++ b/data/muffinhunt-dev/functions/dragon_half_health.mcfunction
@@ -1,3 +1,4 @@
+scoreboard players set EnderDragonHealthCheck EnderDragonHealth 1
 execute at @e[type=armor_stand,tag=DragonMidStand] run summon hoglin ~ ~ ~ {IsImmuneToZombification:1,ActiveEffects:[{Id:28,Duration:10000,ShowParticles:false}]}
 execute at @e[type=armor_stand,tag=DragonMidStand] run summon hoglin ~ ~ ~ {IsImmuneToZombification:1,ActiveEffects:[{Id:28,Duration:10000,ShowParticles:false}]}
 execute at @e[type=armor_stand,tag=DragonMidStand] run summon hoglin ~ ~ ~ {IsImmuneToZombification:1,ActiveEffects:[{Id:28,Duration:10000,ShowParticles:false}]}

--- a/data/muffinhunt-dev/functions/end_crystals_removed.mcfunction
+++ b/data/muffinhunt-dev/functions/end_crystals_removed.mcfunction
@@ -1,0 +1,9 @@
+tellraw @a[tag=muffinhunt] [{"text": "All of the ","color": "gold"},{"text": "End Crystals ","color": "dark_purple"},{"text": "have been destroyed! We've got a surprise in order..."}]
+execute in muffinhunt_the_end positioned 0 50 0 run summon armor_stand ~ ~ ~ {Invisible:1,Marker:1,Tags:["DragonMidStand"]}
+execute at @e[type=armor_stand,tag=DragonMidStand] run summon phantom ~ ~ ~ {PersistenceRequired:1,Size:10}
+execute at @e[type=armor_stand,tag=DragonMidStand] run summon phantom ~ ~ ~ {PersistenceRequired:1,Size:10}
+execute at @e[type=armor_stand,tag=DragonMidStand] run summon phantom ~ ~ ~ {PersistenceRequired:1,Size:10}
+execute at @e[type=armor_stand,tag=DragonMidStand] run summon phantom ~ ~ ~ {PersistenceRequired:1,Size:10}
+execute at @e[type=armor_stand,tag=DragonMidStand] run summon phantom ~ ~ ~ {PersistenceRequired:1,Size:10}
+execute at @e[type=armor_stand,tag=DragonMidStand] run summon phantom ~ ~ ~ {PersistenceRequired:1,Size:10}
+execute at @e[type=armor_stand,tag=DragonMidStand] as @e[type=phantom,distance=..10] at @s run spreadplayers ~ ~ 15 35 false @s

--- a/data/muffinhunt-dev/functions/remove_bossbar.mcfunction
+++ b/data/muffinhunt-dev/functions/remove_bossbar.mcfunction
@@ -1,0 +1,7 @@
+execute as @a[team=endCrystalBossbar] run team leave @s
+execute store result bossbar end_crystal_bossbar value run team list endCrystalBossbar
+bossbar set end_crystal_bossbar visible false
+bossbar set end_crystal_bossbar players
+bossbar remove end_crystal_bossbar
+team remove endCrystalBossbar
+

--- a/data/muffinhunt/functions/enter_end.mcfunction
+++ b/data/muffinhunt/functions/enter_end.mcfunction
@@ -8,4 +8,5 @@ item replace entity @a[team=dragon_ender] container.1 with netherite_pickaxe{Unb
 give @a[team=dragon_ender] spyglass{display:{Name:'[{"text":"Aha!","italic":false,"color":"gold"}]',Lore:['[{"text":"Look at the dragon! Just do it!"}]']}} 1
 give @a[team=juggernaut] spyglass{display:{Name:'[{"text":"Aha!","italic":false,"color":"gold"}]',Lore:['[{"text":"Look at the dragon! Just do it!"}]']}} 1
 tag @a[tag=muffinhunt] add muffinhunt_enter_end
+function muffinhunt-dev:add_enderdragon_health
 tellraw @a ["",{"text":"End","color":"dark_purple"},{"text":" items given!","color":"gold"}]

--- a/data/muffinhunt/functions/enter_end.mcfunction
+++ b/data/muffinhunt/functions/enter_end.mcfunction
@@ -1,12 +1,13 @@
-item replace entity @a[team=juggernaut,tag=!no_juggernaut_pumpkin] armor.head with carved_pumpkin{display:{Name:'[{"text":"Enderman Protector","italic":"false","color":"gold"}]'},Enchantments:[{id:protection,lvl:7}],HideFlags:1} 1
-item replace entity @a[team=juggernaut,tag=no_juggernaut_pumpkin] armor.head with diamond_helmet{Unbreakable:1,display:{Name:'[{"text":"Copper Helmet","italic":"false","color":"gold"}]'}}
-item replace entity @a[team=juggernaut] armor.chest with diamond_chestplate{Unbreakable:1,display:{Name:'[{"text":"Copper Chestplate","italic":"false","color":"gold"}]'},Enchantments:[{id:protection,lvl:1}]}
-item replace entity @a[team=juggernaut] armor.legs with diamond_leggings{Unbreakable:1,display:{Name:'[{"text":"Copper Leggings","italic":"false","color":"gold"}]'}}
-item replace entity @a[team=juggernaut] armor.feet with diamond_boots{Unbreakable:1,display:{Name:'[{"text":"Copper Boots","italic":"false","color":"gold"}]'}}
-item replace entity @a[team=juggernaut] container.2 with netherite_pickaxe{Unbreakable:1,display:{Name:'[{"text":"Copper Pickaxe","color":"#FFA500","italic":"false"}]'},Enchantments:[{id:efficency,lvl:2}]}
-item replace entity @a[team=dragon_ender] container.1 with netherite_pickaxe{Unbreakable:1,display:{Name:'[{"text":"Copper Pickaxe","color":"#FFA500","italic":"false"}]'},Enchantments:[{id:efficency,lvl:2}]}
+item replace entity @a[team=juggernaut,tag=!no_juggernaut_pumpkin] armor.head with carved_pumpkin{display:{Name:'[{"text":"Enderman Protector","italic":false,"color":"gold"}]'},Enchantments:[{id:"protection",lvl:7}],HideFlags:1} 1
+item replace entity @a[team=juggernaut,tag=no_juggernaut_pumpkin] armor.head with diamond_helmet{Unbreakable:1,display:{Name:'[{"text":"Copper Helmet","italic":false,"color":"gold"}]'}}
+item replace entity @a[team=juggernaut] armor.chest with diamond_chestplate{Unbreakable:1,display:{Name:'[{"text":"Copper Chestplate","italic":false,"color":"gold"}]'},Enchantments:[{id:"protection",lvl:1}]}
+item replace entity @a[team=juggernaut] armor.legs with diamond_leggings{Unbreakable:1,display:{Name:'[{"text":"Copper Leggings","italic":false,"color":"gold"}]'}}
+item replace entity @a[team=juggernaut] armor.feet with diamond_boots{Unbreakable:1,display:{Name:'[{"text":"Copper Boots","italic":false,"color":"gold"}]'}}
+item replace entity @a[team=juggernaut] container.2 with netherite_pickaxe{Unbreakable:1,display:{Name:'[{"text":"Copper Pickaxe","color":"#FFA500","italic":false}]'},Enchantments:[{id:"efficiency",lvl:2}]}
+item replace entity @a[team=dragon_ender] container.1 with netherite_pickaxe{Unbreakable:1,display:{Name:'[{"text":"Copper Pickaxe","color":"#FFA500","italic":false}]'},Enchantments:[{id:"efficiency",lvl:2}]}
 give @a[team=dragon_ender] spyglass{display:{Name:'[{"text":"Aha!","italic":false,"color":"gold"}]',Lore:['[{"text":"Look at the dragon! Just do it!"}]']}} 1
 give @a[team=juggernaut] spyglass{display:{Name:'[{"text":"Aha!","italic":false,"color":"gold"}]',Lore:['[{"text":"Look at the dragon! Just do it!"}]']}} 1
 tag @a[tag=muffinhunt] add muffinhunt_enter_end
+function muffinhunt-dev:add_crystal_bossbar
 function muffinhunt-dev:add_enderdragon_health
 tellraw @a ["",{"text":"End","color":"dark_purple"},{"text":" items given!","color":"gold"}]

--- a/data/muffinhunt/functions/enter_nether.mcfunction
+++ b/data/muffinhunt/functions/enter_nether.mcfunction
@@ -1,9 +1,9 @@
-item replace entity @a[team=juggernaut] armor.chest with iron_chestplate{Unbreakable:1,display:{Name:'[{"text":"Emerald Chestplate","color":"green","italic":"false"}]'},Enchantments:[{id:protection,lvl:3}]}
-item replace entity @a[team=juggernaut] armor.legs with iron_leggings{Unbreakable:1,display:{Name:'[{"text":"Emerald Leggings","color":"green","italic":"false"}]'},Enchantments:[{id:protection,lvl:3}]}
-item replace entity @a[team=juggernaut] armor.feet with golden_boots{Unbreakable:1,Enchantments:[{id:protection,lvl:5}]}
-item replace entity @a[team=juggernaut,tag=!no_juggernaut_pumpkin] armor.head with carved_pumpkin{display:{Name:'[{"text":"Enderman Protector","italic":false}]'},Enchantments:[{id:protection,lvl:5}],HideFlags:1} 1
-item replace entity @a[team=juggernaut,tag=no_juggernaut_pumpkin] armor.head with iron_helmet{Unbreakable:1,display:{Name:'[{"text":"Emerald Helmet","color":"green"}]'},Enchantments:[{id:protection,lvl:3}]}
+item replace entity @a[team=juggernaut] armor.chest with iron_chestplate{Unbreakable:1,display:{Name:'[{"text":"Emerald Chestplate","color":"green","italic":false}]'},Enchantments:[{id:"protection",lvl:3}]}
+item replace entity @a[team=juggernaut] armor.legs with iron_leggings{Unbreakable:1,display:{Name:'[{"text":"Emerald Leggings","color":"green","italic":false}]'},Enchantments:[{id:"protection",lvl:3}]}
+item replace entity @a[team=juggernaut] armor.feet with golden_boots{Unbreakable:1,Enchantments:[{id:"protection",lvl:5}]}
+item replace entity @a[team=juggernaut,tag=!no_juggernaut_pumpkin] armor.head with carved_pumpkin{display:{Name:'[{"text":"Enderman Protector","italic":false}]'},Enchantments:[{id:"protection",lvl:5}],HideFlags:1} 1
+item replace entity @a[team=juggernaut,tag=no_juggernaut_pumpkin] armor.head with iron_helmet{Unbreakable:1,display:{Name:'[{"text":"Emerald Helmet","color":"green"}]'},Enchantments:[{id:"protection",lvl:3}]}
 item replace entity @a[team=juggernaut] weapon.offhand with shield{Unbreakable:1}
-item replace entity @a[team=juggernaut] container.2 with diamond_pickaxe{Unbreakable:1,display:{Name:'[{"text":"Emerald Pickaxe","color":"green","italic":"false"}]'},Enchantments:[{id:efficiency,lvl:2}]}
+item replace entity @a[team=juggernaut] container.2 with diamond_pickaxe{Unbreakable:1,display:{Name:'[{"text":"Emerald Pickaxe","color":"green","italic":false}]'},Enchantments:[{id:"efficiency",lvl:2}]}
 tag @a[tag=muffinhunt] add muffinhunt_nether
-tellraw @a ["",{"text":"Nether","color":"red"},{"text":" items given!","color":"gold"},{"text":" "}]
+tellraw @a [{"text":"Nether","color":"red"},{"text":" items given!","color":"gold"}]

--- a/data/muffinhunt/functions/start_muffinhunt.mcfunction
+++ b/data/muffinhunt/functions/start_muffinhunt.mcfunction
@@ -7,12 +7,12 @@ team modify juggernaut friendlyFire false
 team modify juggernaut displayName ["",{"text":"Muffin","color":"yellow"},{"text":"Hunt ","color":"dark_aqua"},{"text":"Juggernaut(s)","color":"dark_aqua"}]
 team modify juggernaut seeFriendlyInvisibles true
 team modify juggernaut color aqua
-team modify juggernaut prefix ["",{"text":"[","color":"aqua"},{"text":"JUGGERNAUT","color":"dark_aqua","bold":"true"},{"text":"] ","color":"aqua"}]
+team modify juggernaut prefix ["",{"text":"[","color":"aqua"},{"text":"JUGGERNAUT","color":"dark_aqua","bold":true},{"text":"] ","color":"aqua"}]
 team join juggernaut @a[tag=juggernaut]
 team add dragon_ender
 team modify dragon_ender displayName ["",{"text":"Muffin","color":"yellow"},{"text":"Hunt","color":"dark_aqua"},{"text":" Dragon Ender","color":"dark_purple"}]
 team modify dragon_ender color dark_purple
-team modify dragon_ender prefix ["",{"text":"[","color":"dark_purple"},{"text":"DRAGON ENDER","color":"light_purple","bold":"true"},{"text":"] ","color":"dark_purple"}]
+team modify dragon_ender prefix ["",{"text":"[","color":"dark_purple"},{"text":"DRAGON ENDER","color":"light_purple","bold":true},{"text":"] ","color":"dark_purple"}]
 team join dragon_ender @a[tag=dragon_ender]
 tag @a[team=juggernaut] remove juggernaut
 tag @a[team=dragon_ender] remove dragon_ender
@@ -20,22 +20,22 @@ scoreboard players set @a MuffinHuntRunnerLives 0
 scoreboard objectives setdisplay list MuffinHuntRunnerLives 
 clear @a[tag=muffinhunt] 
 advancement revoke @a[tag=muffinhunt] everything
-give @a[team=juggernaut] iron_sword{Unbreakable:1,display:{Name:'[{"text":"Emerald Sword","color":"green","italic":"false"}]'}} 1
+give @a[team=juggernaut] iron_sword{Unbreakable:1,display:{Name:'[{"text":"Emerald Sword","color":"green","italic":false}]'}} 1
 give @a[team=juggernaut] cobbled_deepslate 64
-item replace entity @a[team=juggernaut] hotbar.2 with diamond_pickaxe{Unbreakable:1,display:{Name:'[{"text":"Diamond Pickaxe","color":"dark_aqua","italic":"false"}]'}} 1
-item replace entity @a[team=juggernaut] hotbar.3 with golden_axe{Unbreakable:1,Enchantments:[{id:efficiency,lvl:3}],display:{Name:'[{"text":"Power Chopper","italic":"false","color":"gold"}]'},HideFlags:2}
+item replace entity @a[team=juggernaut] hotbar.2 with diamond_pickaxe{Unbreakable:1,display:{Name:'[{"text":"Diamond Pickaxe","color":"dark_aqua","italic":false}]'}} 1
+item replace entity @a[team=juggernaut] hotbar.3 with golden_axe{Unbreakable:1,Enchantments:[{id:"efficiency",lvl:3}],display:{Name:'[{"text":"Power Chopper","italic":false,"color":"gold"}]'},HideFlags:2}
 item replace entity @a[team=dragon_ender] weapon.offhand with shield{Unbreakable:1} 1 
 give @a[team=dragon_ender] stone_sword{Unbreakable:1}
 give @a[team=dragon_ender] netherite_pickaxe{Unbreakable:1} 1
-give @a[team=dragon_ender] golden_axe{Unbreakable:1,Enchantments:[{id:efficiency,lvl:3}],display:{Name:'[{"text":"Power Chopper","italic":"false","color":"gold"}]'},HideFlags:2}
+give @a[team=dragon_ender] golden_axe{Unbreakable:1,Enchantments:[{id:"efficiency",lvl:3}],display:{Name:'[{"text":"Power Chopper","italic":false,"color":"gold"}]'},HideFlags:2}
 give @a[team=dragon_ender] anvil 1
 give @a[team=dragon_ender] cobbled_deepslate 64
-item replace entity @a[team=dragon_ender] armor.chest with chainmail_chestplate{Unbreakable:1,Enchantments:[{id:protection,lvl:1}],HideFlags:1} 1
-give @a[tag=muffinhunt] water_bucket{display:{Name:'[{"text":"Water Bucket","color":"blue","italic":"false"}]'}} 1
-give @a[tag=muffinhunt] cooked_beef{display:{Name:'[{"text":"Burger","italic":"false","color":"#964B00"}]'}} 64
-give @a[tag=muffinhunt] oak_planks{display:{Name:'[{"text":"Oak Planks","color":"gold","italic":"false"}]'}} 64
-give @a[tag=muffinhunt] coal{display:{Name:'[{"text":"Coal","color":"black","italic":"false"}]'}} 64
-give @a[tag=muffinhunt] iron_shovel{Unbreakable:1,display:{Name:'[{"text":"Power Digger","italic":false,"color":"gold"}]'},Enchantments:[{id:efficiency,lvl:3}],HideFlags:101}
+item replace entity @a[team=dragon_ender] armor.chest with chainmail_chestplate{Unbreakable:1,Enchantments:[{id:"protection",lvl:1}],HideFlags:1} 1
+give @a[tag=muffinhunt] water_bucket{display:{Name:'[{"text":"Water Bucket","color":"blue","italic":false}]'}} 1
+give @a[tag=muffinhunt] cooked_beef{display:{Name:'[{"text":"Burger","italic":false,"color":"#964B00"}]'}} 64
+give @a[tag=muffinhunt] oak_planks{display:{Name:'[{"text":"Oak Planks","color":"gold","italic":false}]'}} 64
+give @a[tag=muffinhunt] coal{display:{Name:'[{"text":"Coal","color":"black","italic":false}]'}} 64
+give @a[tag=muffinhunt] iron_shovel{Unbreakable:1,display:{Name:'[{"text":"Power Digger","italic":false,"color":"gold"}]'},Enchantments:[{id:"efficiency",lvl:3}],HideFlags:101}
 item replace entity @a[team=juggernaut] armor.chest with iron_chestplate{Unbreakable:1,display:{Name:'[{"text":"Emerald Chestplate","italic":false,"color":"green"}]'}} 1
 item replace entity @a[team=juggernaut] armor.legs with iron_leggings{Unbreakable:1,display:{Name:'[{"text":"Emerald Leggings","italic":false,"color":"green"}]'}} 1
 item replace entity @a[team=juggernaut] armor.feet with iron_boots{Unbreakable:1,display:{Name:'[{"text":"Emerald Boots","italic":false,"color":"green"}]'}} 1

--- a/data/muffinhunt/functions/surface_overworld.mcfunction
+++ b/data/muffinhunt/functions/surface_overworld.mcfunction
@@ -1,9 +1,9 @@
-item replace entity @a[team=juggernaut] armor.chest with diamond_chestplate{Unbreakable:1,display:{Name:'[{"text":"Copper Chestplate","color":"#FFA500","italic":"false"}]'}}
+item replace entity @a[team=juggernaut] armor.chest with diamond_chestplate{Unbreakable:1,display:{Name:'[{"text":"Copper Chestplate","color":"#FFA500","italic":false}]'}}
 give @a[team=juggernaut] emerald 128
 item replace entity @a[team=juggernaut] container.1 with bow{Unbreakable:1}
-item replace entity @a[team=juggernaut] container.2 with netherite_pickaxe{Unbreakable:1,display:{Name:'[{"text":"Emerald Pickaxe","color":"green","italic":"false"}]'},}
+item replace entity @a[team=juggernaut] container.2 with netherite_pickaxe{Unbreakable:1,display:{Name:'[{"text":"Emerald Pickaxe","color":"green","italic":false}]'}}
 item replace entity @a[team=dragon_ender] weapon.offhand with shield{Damage:73}
-item replace entity @a[team=juggernaut] armor.feet with diamond_boots{Unbreakable:1,display:{Name:'[{"text":"Copper Boots","color":"#FFA500","italic":"false"}]'}}	
-item replace entity @a[team=juggernaut] container.0 with diamond_sword{Unbreakable:1,display:{Name:'[{"text":"Copper Sword","color":"#FFA500","italic":"false"}]'}}
+item replace entity @a[team=juggernaut] armor.feet with diamond_boots{Unbreakable:1,display:{Name:'[{"text":"Copper Boots","color":"#FFA500","italic":false}]'}}
+item replace entity @a[team=juggernaut] container.0 with diamond_sword{Unbreakable:1,display:{Name:'[{"text":"Copper Sword","color":"#FFA500","italic":false}]'}}
 tag @a[tag=muffinhunt] add muffinhunt_surface_overworld
 tellraw @a [{"text":"Surface Overworld ","color":"green"},{"text":"items given! ","color":"gold"}]

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,20 +1,23 @@
-# This is a list of all tags used by this datapack. Do not edit unless you change the tags elsewhere.
+# This is a list of all tags used by this datapack. Do not edit unless you change the tags elsewhere
 
-# Standard tags, only used on start 
+## Standard tags, only used on start
+
 Juggernaut: juggernaut
 Dragon Ender: dragon_ender
 
-# Permanent tags
+## Permanent tags
+
 Permanent Juggernaut: usual_juggernaut
 Permanent Dragon Ender: usual_dragon_ender
 No Carved Pumpkin: no_juggernaut_pumpkin
 
-# Standard teams
+## Standard teams
+
 Juggernaut: juggernaut
 Dragon Ender: dragon_ender
 
-# Universal tags
+## Universal tags
+
 MuffinHunt player: muffinhunt
 MuffinHunt permanent (until removed) ban: muffinhunt_ban
 MuffinHunt tempban/spectator: muffinhunt_spectato
-


### PR DESCRIPTION
## Purpose
This'll be a bigger one. Adding mobs at the end (that look different from vanilla mobs, textures by @M3FF1N). Depends partially on #48.

## Approach
Add health scoreboards for the Ender Dragon and therefore detect and run functions when at a certain health point.

## Future work
Should be none. I don't know, because this *could* break something.

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/osfanbuff63/muffinhunt-datapack/blob/master/README.md) and/or [docs folder](/docs)
- [ ] Tested in the latest version of Minecraft
