### PR TITLE
Add end caves

### DIFF
--- a/data/minecraft/dimension/the_end.json
+++ b/data/minecraft/dimension/the_end.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:the_end",
+  "generator": {
+    "type": "minecraft:noise",
+    "seed": -767523286,
+    "settings": "muffinhunt:end_with_caves",
+    "biome_source": {
+      "type": "minecraft:the_end",
+      "seed": -767523286
+    }
+  }
+}

--- a/data/minecraft/worldgen/biome/the_end.json
+++ b/data/minecraft/worldgen/biome/the_end.json
@@ -1,0 +1,77 @@
+{
+	"temperature": 0.5,
+	"downfall": 0.5,
+	"precipitation": "none",
+	"temperature_modifier": "none",
+	"category": "the_end",
+	"effects": {
+		"sky_color": 0,
+		"fog_color": 10518688,
+		"water_color": 4159204,
+		"water_fog_color": 329011,
+		"mood_sound": {
+			"sound": "minecraft:ambient.cave",
+			"tick_delay": 6000,
+			"block_search_extent": 8,
+			"offset": 2
+		}
+	},
+	"spawners": {
+		"monster": [{
+			"type": "minecraft:enderman",
+			"weight": 10,
+			"minCount": 4,
+			"maxCount": 4
+		}],
+		"creature": [],
+		"ambient": [],
+		"axolotls": [],
+		"underground_water_creature": [],
+		"water_creature": [],
+		"water_ambient": [],
+		"misc": []
+	},
+	"spawn_costs": {},
+	"carvers": {
+		"air": [
+			"minecraft:cave"
+		]
+	},
+ "features": [
+    [
+      "minecraft:ore_dirt",
+      "minecraft:ore_gravel",
+      "minecraft:ore_granite_upper",
+      "minecraft:ore_granite_lower",
+      "minecraft:ore_diorite_upper",
+      "minecraft:ore_diorite_lower",
+      "minecraft:ore_andesite_upper",
+      "minecraft:ore_andesite_lower",
+      "minecraft:ore_tuff",
+      "minecraft:ore_coal_upper",
+      "minecraft:ore_coal_lower",
+      "minecraft:ore_iron_upper",
+      "minecraft:ore_iron_middle",
+      "minecraft:ore_iron_small",
+      "minecraft:ore_gold",
+      "minecraft:ore_gold_lower",
+      "minecraft:ore_redstone",
+      "minecraft:ore_redstone_lower",
+      "minecraft:ore_diamond",
+      "minecraft:ore_diamond_large",
+      "minecraft:ore_diamond_buried",
+      "minecraft:ore_lapis",
+      "minecraft:ore_lapis_buried",
+      "minecraft:ore_copper",
+      "minecraft:underwater_magma",
+      "minecraft:disk_sand",
+      "minecraft:disk_clay",
+      "minecraft:disk_gravel",
+      "minecraft:ore_emerald"
+    ],
+    [
+      "minecraft:end_spike",
+      "minecraft:end_island_decorated"
+    ]
+  ]
+}

--- a/data/muffinhunt/worldgen/noise_settings/end_with_caves.json
+++ b/data/muffinhunt/worldgen/noise_settings/end_with_caves.json
@@ -1,0 +1,57 @@
+{
+  "sea_level": 0,
+  "disable_mob_generation": true,
+  "noise_caves_enabled": true,
+  "noodle_caves_enabled": true,
+  "aquifers_enabled": false,
+  "ore_veins_enabled": true,
+  "legacy_random_source": true,
+  "default_block": {
+    "Name": "minecraft:end_stone"
+  },
+  "default_fluid": {
+    "Name": "minecraft:air"
+  },
+  "noise": {
+    "min_y": 0,
+    "height": 128,
+    "size_horizontal": 2,
+    "size_vertical": 1,
+    "sampling": {
+      "xz_scale": 2,
+      "y_scale": 1,
+      "xz_factor": 80,
+      "y_factor": 160
+    },
+    "bottom_slide": {
+      "target": -0.234375,
+      "size": 7,
+      "offset": 1
+    },
+    "top_slide": {
+      "target": -23.4375,
+      "size": 64,
+      "offset": -46
+    },
+    "terrain_shaper": {
+      "offset": 0,
+      "factor": 0,
+      "jaggedness": 0
+    }
+  },
+  "surface_rule": {
+    "type": "minecraft:block",
+    "result_state": {
+      "Name": "minecraft:end_stone"
+    }
+  },
+  "structures": {
+    "structures": {
+      "minecraft:endcity": {
+        "spacing": 7,
+        "separation": 3,
+        "salt": 0
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Purpose
Fixes #43, adds caves to the end.

## Approach
Add `noise` and `noodle` cave types to the End dimension.

## Future work
Figure out how to create pre-1.18 caves, as that's what we really want.

#### Checklist
- [x] Included tests
- [ ] Updated documentation in [README](https://github.com/osfanbuff63/muffinhunt-datapack/blob/master/README.md) and/or [docs folder](/docs)
- [ ] Tested in the latest version of Minecraft


