### PR TITLE
Fix 1.18.2 again

### DIFF
--- a/data/minecraft/advancements/nether/find_bastion.json
+++ b/data/minecraft/advancements/nether/find_bastion.json
@@ -1,28 +1,27 @@
 {
-    "display": {
-      "icon": {
-        "item": "minecraft:polished_blackstone"
-      },
-      "title": "Those were the days..",
-      "description": "...that muffin didn't get the loot",
-      "frame": "task",
-      "show_toast": true,
-      "announce_to_chat": true,
-      "hidden": false
+  "display": {
+    "icon": {
+      "item": "minecraft:polished_blackstone"
     },
-    "parent": "muffinhunt:infinite_amethyst",
-    "criteria": {
-      "requirement": {
-        "trigger": "minecraft:location",
-        "conditions": {
-          "location": {
-            "feature": "bastion_remnant"
-          }
+    "title": "Those were the days..",
+    "description": "...that muffin didn't get the loot",
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false
+  },
+  "parent": "muffinhunt:infinite_amethyst",
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:location",
+      "conditions": {
+        "location": {
+          "feature": "minecraft:bastion_remnant"
         }
       }
-    },
-    "rewards": {
-      "experience": 50
     }
+  },
+  "rewards": {
+    "experience": 50
   }
-  
+}

--- a/data/minecraft/loot_tables/chests/nether_bridge.json
+++ b/data/minecraft/loot_tables/chests/nether_bridge.json
@@ -1,99 +1,98 @@
 {
-    "pools": [
-      {
-        "rolls": 5,
-        "bonus_rolls": 1,
-        "entries": [
-          {
-            "type": "minecraft:item",
-            "weight": 5,
-            "name": "minecraft:coal"
-          },
-          {
-            "type": "minecraft:item",
-            "weight": 1,
-            "name": "minecraft:netherite_ingot",
-            "conditions": [
-               {
-                "condition": "minecraft:random_chance",
-                "chance": 0.5
-               }
-            ],
-            "functions": [
-              {
-                "function": "minecraft:set_count",
-                "count": 1
-              }
-            ]
-          },
-          {
-            "type": "minecraft:item",
-            "weight": 3,
-            "name": "minecraft:ancient_debris"
-          },
-          {
-            "type": "minecraft:item",
-            "weight": 4,
-            "name": "minecraft:gold_ingot"
-          },
-          {
-            "type": "minecraft:item",
-            "weight": 4,
-            "name": "minecraft:iron_ingot"
-          },
-          {
-            "type": "minecraft:item",
-            "weight": 3,
-            "name": "minecraft:iron_pickaxe",
-            "functions": [
-              {
-                "function": "minecraft:set_count",
-                "count": 1
-              },
-              {
-                "function": "minecraft:enchant_randomly",
-                "conditions": [
-                  {
-                    "condition": "minecraft:random_chance",
-                    "chance": 0.5
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "type": "minecraft:item",
-            "weight": 2,
-            "name": "minecraft:diamond",
-            "functions": [
-              {
-                "function": "minecraft:set_count",
-                "count": 1
-              }
-            ]
-          },
-          {
-            "type": "minecraft:item",
-            "weight": 1,
-            "name": "minecraft:diamond_helmet",
-            "functions": [
-              {
-                "function": "minecraft:set_count",
-                "count": 1
-              },
-              {
-                "function": "minecraft:enchant_randomly",
-                "conditions": [
-                  {
-                    "condition": "minecraft:random_chance",
-                    "chance": 0.05
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  }
-  
+  "pools": [
+    {
+      "rolls": 5,
+      "bonus_rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "weight": 5,
+          "name": "minecraft:coal"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 1,
+          "name": "minecraft:netherite_ingot",
+          "conditions": [
+            {
+              "condition": "minecraft:random_chance",
+              "chance": 0.5
+            }
+          ],
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 3,
+          "name": "minecraft:ancient_debris"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 4,
+          "name": "minecraft:gold_ingot"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 4,
+          "name": "minecraft:iron_ingot"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 3,
+          "name": "minecraft:iron_pickaxe",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1
+            },
+            {
+              "function": "minecraft:enchant_randomly",
+              "conditions": [
+                {
+                  "condition": "minecraft:random_chance",
+                  "chance": 0.5
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 2,
+          "name": "minecraft:diamond",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 1,
+          "name": "minecraft:diamond_helmet",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1
+            },
+            {
+              "function": "minecraft:enchant_randomly",
+              "conditions": [
+                {
+                  "condition": "minecraft:random_chance",
+                  "chance": 0.05
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/minecraft/loot_tables/entities/bat.json
+++ b/data/minecraft/loot_tables/entities/bat.json
@@ -1,32 +1,31 @@
 {
-    "type": "minecraft:entity",
-    "pools": [
-      {
-        "rolls": 3,
-        "entries": [
-          {
-            "type": "minecraft:item",
-            "name": "minecraft:emerald_block",
-            "functions": [
-              {
-                "function": "minecraft:set_count",
-                "count": {
-                  "type": "minecraft:uniform",
-                  "min": 1,
-                  "max": 5
-                },
-                "add": true,
-                "conditions": [
-                  {
-                    "condition": "minecraft:random_chance",
-                    "chance": 0.7
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  }
-  
+  "type": "minecraft:entity",
+  "pools": [
+    {
+      "rolls": 3,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:emerald_block",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 1,
+                "max": 5
+              },
+              "add": true,
+              "conditions": [
+                {
+                  "condition": "minecraft:random_chance",
+                  "chance": 0.7
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/minecraft/worldgen/biome/the_end.json
+++ b/data/minecraft/worldgen/biome/the_end.json
@@ -17,12 +17,14 @@
 		}
 	},
 	"spawners": {
-		"monster": [{
-			"type": "minecraft:enderman",
-			"weight": 10,
-			"minCount": 4,
-			"maxCount": 4
-		}],
+		"monster": [
+			{
+				"type": "minecraft:enderman",
+				"weight": 10,
+				"minCount": 4,
+				"maxCount": 4
+			}
+		],
 		"creature": [],
 		"ambient": [],
 		"axolotls": [],
@@ -37,41 +39,41 @@
 			"minecraft:cave"
 		]
 	},
- "features": [
-    [
-      "minecraft:ore_dirt",
-      "minecraft:ore_gravel",
-      "minecraft:ore_granite_upper",
-      "minecraft:ore_granite_lower",
-      "minecraft:ore_diorite_upper",
-      "minecraft:ore_diorite_lower",
-      "minecraft:ore_andesite_upper",
-      "minecraft:ore_andesite_lower",
-      "minecraft:ore_tuff",
-      "minecraft:ore_coal_upper",
-      "minecraft:ore_coal_lower",
-      "minecraft:ore_iron_upper",
-      "minecraft:ore_iron_middle",
-      "minecraft:ore_iron_small",
-      "minecraft:ore_gold",
-      "minecraft:ore_gold_lower",
-      "minecraft:ore_redstone",
-      "minecraft:ore_redstone_lower",
-      "minecraft:ore_diamond",
-      "minecraft:ore_diamond_large",
-      "minecraft:ore_diamond_buried",
-      "minecraft:ore_lapis",
-      "minecraft:ore_lapis_buried",
-      "minecraft:ore_copper",
-      "minecraft:underwater_magma",
-      "minecraft:disk_sand",
-      "minecraft:disk_clay",
-      "minecraft:disk_gravel",
-      "minecraft:ore_emerald"
-    ],
-    [
-      "minecraft:end_spike",
-      "minecraft:end_island_decorated"
-    ]
-  ]
+	"features": [
+		[
+			"minecraft:ore_dirt",
+			"minecraft:ore_gravel",
+			"minecraft:ore_granite_upper",
+			"minecraft:ore_granite_lower",
+			"minecraft:ore_diorite_upper",
+			"minecraft:ore_diorite_lower",
+			"minecraft:ore_andesite_upper",
+			"minecraft:ore_andesite_lower",
+			"minecraft:ore_tuff",
+			"minecraft:ore_coal_upper",
+			"minecraft:ore_coal_lower",
+			"minecraft:ore_iron_upper",
+			"minecraft:ore_iron_middle",
+			"minecraft:ore_iron_small",
+			"minecraft:ore_gold",
+			"minecraft:ore_gold_lower",
+			"minecraft:ore_redstone",
+			"minecraft:ore_redstone_lower",
+			"minecraft:ore_diamond",
+			"minecraft:ore_diamond_large",
+			"minecraft:ore_diamond_buried",
+			"minecraft:ore_lapis",
+			"minecraft:ore_lapis_buried",
+			"minecraft:ore_copper",
+			"minecraft:underwater_magma",
+			"minecraft:disk_sand",
+			"minecraft:disk_clay",
+			"minecraft:disk_gravel",
+			"minecraft:ore_emerald"
+		],
+		[
+			"minecraft:end_spike",
+			"minecraft:end_island_decorated"
+		]
+	]
 }

--- a/data/muffinhunt/advancements/c-a-v-e.json
+++ b/data/muffinhunt/advancements/c-a-v-e.json
@@ -1,38 +1,37 @@
 {
-    "display": {
-      "icon": {
-        "item": "minecraft:moss_block"
-      },
-      "title": "c a v e",
-      "description": "Find all cave biomes",
-      "show_toast": true,
-      "announce_to_chat": true,
-      "hidden": false
+  "display": {
+    "icon": {
+      "item": "minecraft:moss_block"
     },
-    "parent": "muffinhunt:infinite_amethyst",
-    "criteria": {
-      "lush_caves": {
-        "trigger": "minecraft:location",
-        "conditions": {
-          "location": {
-            "biome": "minecraft:lush_caves"
-          }
-        }
-      },
-      "dripstone_caves": {
-        "trigger": "minecraft:location",
-        "conditions": {
-          "location": {
-            "biome": "minecraft:dripstone_caves"
-          }
+    "title": "c a v e",
+    "description": "Find all cave biomes",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false
+  },
+  "parent": "muffinhunt:infinite_amethyst",
+  "criteria": {
+    "lush_caves": {
+      "trigger": "minecraft:location",
+      "conditions": {
+        "location": {
+          "biome": "minecraft:lush_caves"
         }
       }
     },
-    "requirements": [
-      [
-        "dripstone_caves",
-        "lush_caves"
-      ]
+    "dripstone_caves": {
+      "trigger": "minecraft:location",
+      "conditions": {
+        "location": {
+          "biome": "minecraft:dripstone_caves"
+        }
+      }
+    }
+  },
+  "requirements": [
+    [
+      "dripstone_caves",
+      "lush_caves"
     ]
-  }
-  
+  ]
+}

--- a/data/muffinhunt/advancements/end_city_loot.json
+++ b/data/muffinhunt/advancements/end_city_loot.json
@@ -1,23 +1,22 @@
 {
-    "display": {
-      "icon": {
-        "item": "minecraft:purpur_block"
-      },
-      "title": "The secret chest...",
-      "description": "Open a chest in an end city",
-      "frame": "goal",
-      "show_toast": true,
-      "announce_to_chat": true,
-      "hidden": false
+  "display": {
+    "icon": {
+      "item": "minecraft:purpur_block"
     },
-    "parent": "minecraft:story/enter_the_end",
-    "criteria": {
-      "requirement": {
-        "trigger": "minecraft:player_generates_container_loot",
-        "conditions": {
-          "loot_table": "minecraft:chests/end_city_treasure"
-        }
+    "title": "The secret chest...",
+    "description": "Open a chest in an end city",
+    "frame": "goal",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false
+  },
+  "parent": "minecraft:story/enter_the_end",
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:player_generates_container_loot",
+      "conditions": {
+        "loot_table": "minecraft:chests/end_city_treasure"
       }
     }
   }
-  
+}

--- a/data/muffinhunt/advancements/goat.json
+++ b/data/muffinhunt/advancements/goat.json
@@ -1,25 +1,24 @@
 {
-    "display": {
-      "icon": {
-        "item": "minecraft:amethyst_block"
-      },
-      "title": "AAAAH",
-      "description": "g o a t (Punch a goat)",
-      "frame": "task",
-      "show_toast": true,
-      "announce_to_chat": true,
-      "hidden": false
+  "display": {
+    "icon": {
+      "item": "minecraft:amethyst_block"
     },
-    "parent": "muffinhunt:infinite_amethyst",
-    "criteria": {
-      "requirement": {
-        "trigger": "minecraft:player_hurt_entity",
-        "conditions": {
-          "entity": {
-            "type": "minecraft:goat"
-          }
+    "title": "AAAAH",
+    "description": "g o a t (Punch a goat)",
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false
+  },
+  "parent": "muffinhunt:infinite_amethyst",
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:player_hurt_entity",
+      "conditions": {
+        "entity": {
+          "type": "minecraft:goat"
         }
       }
     }
   }
-  
+}

--- a/data/muffinhunt/advancements/i_ate_it.json
+++ b/data/muffinhunt/advancements/i_ate_it.json
@@ -1,27 +1,26 @@
 {
-    "display": {
-      "icon": {
-        "item": "minecraft:cooked_beef",
-        "nbt": "{CustomName:'[{\"text\":\"Burger\"}]'}"
-      },
-      "title": "I ate it",
-      "description": "Eat a burger",
-      "show_toast": true,
-      "announce_to_chat": true,
-      "hidden": false
+  "display": {
+    "icon": {
+      "item": "minecraft:cooked_beef",
+      "nbt": "{CustomName:'[{\"text\":\"Burger\"}]'}"
     },
-    "parent": "muffinhunt:infinite_amethyst",
-    "criteria": {
-      "requirement": {
-        "trigger": "minecraft:consume_item",
-        "conditions": {
-          "item": {
-            "items": [
-              "minecraft:cooked_beef"
-            ]
-          }
+    "title": "I ate it",
+    "description": "Eat a burger",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false
+  },
+  "parent": "muffinhunt:infinite_amethyst",
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:consume_item",
+      "conditions": {
+        "item": {
+          "items": [
+            "minecraft:cooked_beef"
+          ]
         }
       }
     }
   }
-  
+}

--- a/data/muffinhunt/advancements/infinite_amethyst.json
+++ b/data/muffinhunt/advancements/infinite_amethyst.json
@@ -1,27 +1,26 @@
 {
-    "display": {
-      "icon": {
-        "item": "minecraft:amethyst_shard"
-      },
-      "title": "Infinite Amethyst",
-      "description": "Obtain amethyst",
-      "frame": "task",
-      "show_toast": true,
-      "announce_to_chat": true,
-      "hidden": false
+  "display": {
+    "icon": {
+      "item": "minecraft:amethyst_shard"
     },
-    "parent": "muffinhunt:punch_osfan",
-    "criteria": {
-      "requirement": {
-        "trigger": "minecraft:inventory_changed",
-        "conditions": {
-          "items": [
-            {
-              "tag": "muffinhunt:amethyst_items"
-            }
-          ]
-        }
+    "title": "Infinite Amethyst",
+    "description": "Obtain amethyst",
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false
+  },
+  "parent": "muffinhunt:punch_osfan",
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "muffinhunt:amethyst_items"
+          }
+        ]
       }
     }
   }
-  
+}

--- a/data/muffinhunt/advancements/iron_man.json
+++ b/data/muffinhunt/advancements/iron_man.json
@@ -1,33 +1,32 @@
 {
-    "display": {
-      "icon": {
-        "item": "minecraft:iron_chestplate",
-        "nbt": "{Enchantments:[{}]}"
-      },
-      "title": "Iron Man",
-      "description": "Obtain full iron armor",
-      "frame": "task",
-      "show_toast": true,
-      "announce_to_chat": true,
-      "hidden": false
+  "display": {
+    "icon": {
+      "item": "minecraft:iron_chestplate",
+      "nbt": "{Enchantments:[{}]}"
     },
-    "parent": "muffinhunt:punch_osfan",
-    "criteria": {
-      "requirement": {
-        "trigger": "minecraft:inventory_changed",
-        "conditions": {
-          "items": [
-            {
-              "items": [
-                "minecraft:iron_helmet",
-                "minecraft:iron_chestplate",
-                "minecraft:iron_leggings",
-                "minecraft:iron_boots"
-              ]
-            }
-          ]
-        }
+    "title": "Iron Man",
+    "description": "Obtain full iron armor",
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false
+  },
+  "parent": "muffinhunt:punch_osfan",
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:iron_helmet",
+              "minecraft:iron_chestplate",
+              "minecraft:iron_leggings",
+              "minecraft:iron_boots"
+            ]
+          }
+        ]
       }
     }
   }
-  
+}

--- a/data/muffinhunt/advancements/netherite_ingot.json
+++ b/data/muffinhunt/advancements/netherite_ingot.json
@@ -1,29 +1,28 @@
 {
-    "display": {
-      "icon": {
-        "item": "minecraft:netherite_ingot"
-      },
-      "title": "So much power...",
-      "description": "Get a Netherite Ingot",
-      "frame": "challenge",
-      "show_toast": true,
-      "announce_to_chat": true,
-      "hidden": false
+  "display": {
+    "icon": {
+      "item": "minecraft:netherite_ingot"
     },
-    "parent": "minecraft:story/enter_the_nether",
-    "criteria": {
-      "requirement": {
-        "trigger": "minecraft:inventory_changed",
-        "conditions": {
-          "items": [
-            {
-              "items": [
-                "minecraft:netherite_ingot"
-              ]
-            }
-          ]
-        }
+    "title": "So much power...",
+    "description": "Get a Netherite Ingot",
+    "frame": "challenge",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false
+  },
+  "parent": "minecraft:story/enter_the_nether",
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:netherite_ingot"
+            ]
+          }
+        ]
       }
     }
   }
-  
+}

--- a/data/muffinhunt/advancements/obtain_looting_book.json
+++ b/data/muffinhunt/advancements/obtain_looting_book.json
@@ -1,39 +1,38 @@
 {
-    "display": {
-      "icon": {
-        "item": "minecraft:enchanted_book",
-        "nbt": "{Enchantments:[{}]}"
-      },
-      "title": "Knowledge is power",
-      "description": "Get a Looting 3 book",
-      "frame": "task",
-      "show_toast": true,
-      "announce_to_chat": true,
-      "hidden": false
+  "display": {
+    "icon": {
+      "item": "minecraft:enchanted_book",
+      "nbt": "{Enchantments:[{}]}"
     },
-    "parent": "minecraft:story/enter_the_nether",
-    "criteria": {
-      "requirement": {
-        "trigger": "minecraft:inventory_changed",
-        "conditions": {
-          "items": [
-            {
-              "items": [
-                "minecraft:enchanted_book"
-              ],
-              "enchantments": [
-                {
-                  "enchantment": "minecraft:looting",
-                  "levels": 3
-                }
-              ]
-            }
-          ]
-        }
+    "title": "Knowledge is power",
+    "description": "Get a Looting 3 book",
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false
+  },
+  "parent": "minecraft:story/enter_the_nether",
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:enchanted_book"
+            ],
+            "enchantments": [
+              {
+                "enchantment": "minecraft:looting",
+                "levels": 3
+              }
+            ]
+          }
+        ]
       }
-    },
-    "rewards": {
-      "experience": 50
     }
+  },
+  "rewards": {
+    "experience": 50
   }
-  
+}

--- a/data/muffinhunt/advancements/punch_a_bat.json
+++ b/data/muffinhunt/advancements/punch_a_bat.json
@@ -1,25 +1,25 @@
 {
-    "display": {
-      "icon": {
-        "item": "minecraft:player_head",
-        "nbt": "{SkullOwner:{Id:[I;1331404383,-1076739259,-1376811539,1267859806],Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjY4MWE3MmRhNzI2M2NhOWFlZjA2NjU0MmVjY2E3YTE4MGM0MGUzMjhjMDQ2M2ZjYjExNGNiM2I4MzA1NzU1MiJ9fX0=\"}]}}} 1"
-      },
-      "title": "Punch the bat",
-      "description": "Kill a bat",
-      "frame": "task",
-      "show_toast": true,
-      "announce_to_chat": true,
-      "hidden": false
+  "display": {
+    "icon": {
+      "item": "minecraft:player_head",
+      "nbt": "{SkullOwner:{Id:[I;1331404383,-1076739259,-1376811539,1267859806],Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjY4MWE3MmRhNzI2M2NhOWFlZjA2NjU0MmVjY2E3YTE4MGM0MGUzMjhjMDQ2M2ZjYjExNGNiM2I4MzA1NzU1MiJ9fX0=\"}]}}} 1"
     },
-    "parent": "muffinhunt:infinite_amethyst",
-    "criteria": {
-      "requirement": {
-        "trigger": "minecraft:player_killed_entity",
-        "conditions": {
-          "entity": {
-            "type": "minecraft:bat"
-          }
+    "title": "Punch the bat",
+    "description": "Kill a bat",
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false
+  },
+  "parent": "muffinhunt:infinite_amethyst",
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:player_killed_entity",
+      "conditions": {
+        "entity": {
+          "type": "minecraft:bat"
         }
       }
     }
   }
+}

--- a/data/muffinhunt/advancements/raw_iron.json
+++ b/data/muffinhunt/advancements/raw_iron.json
@@ -1,29 +1,28 @@
 {
-    "display": {
-      "icon": {
-        "item": "minecraft:raw_iron"
-      },
-      "title": "Raw Metal",
-      "description": "Get raw iron",
-      "frame": "task",
-      "show_toast": true,
-      "announce_to_chat": true,
-      "hidden": false
+  "display": {
+    "icon": {
+      "item": "minecraft:raw_iron"
     },
-    "parent": "muffinhunt:punch_osfan",
-    "criteria": {
-      "requirement": {
-        "trigger": "minecraft:inventory_changed",
-        "conditions": {
-          "items": [
-            {
-              "items": [
-                "minecraft:raw_iron"
-              ]
-            }
-          ]
-        }
+    "title": "Raw Metal",
+    "description": "Get raw iron",
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false
+  },
+  "parent": "muffinhunt:punch_osfan",
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:raw_iron"
+            ]
+          }
+        ]
       }
     }
   }
-  
+}

--- a/data/muffinhunt/advancements/shield_broke.json
+++ b/data/muffinhunt/advancements/shield_broke.json
@@ -1,28 +1,27 @@
 {
-    "display": {
-      "icon": {
-        "item": "minecraft:shield"
-      },
-      "title": "Where'd my shield go?",
-      "description": "I ate it (it broke)",
-      "show_toast": true,
-      "announce_to_chat": true,
-      "hidden": false
+  "display": {
+    "icon": {
+      "item": "minecraft:shield"
     },
-    "parent": "muffinhunt:i_ate_it",
-    "criteria": {
-      "requirement": {
-        "trigger": "minecraft:item_durability_changed",
-        "conditions": {
-          "durability": 0,
-          "item": {
-            "items": [
-              "minecraft:shield"
-            ],
-            "durability": 0
-          }
+    "title": "Where'd my shield go?",
+    "description": "I ate it (it broke)",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false
+  },
+  "parent": "muffinhunt:i_ate_it",
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:item_durability_changed",
+      "conditions": {
+        "durability": 0,
+        "item": {
+          "items": [
+            "minecraft:shield"
+          ],
+          "durability": 0
         }
       }
     }
   }
-  
+}

--- a/data/muffinhunt/advancements/spyglass_at_muffin.json
+++ b/data/muffinhunt/advancements/spyglass_at_muffin.json
@@ -1,44 +1,43 @@
 {
-    "display": {
-      "icon": {
-        "item": "minecraft:spyglass"
-      },
-      "title": "Is it a speedrunner? In full diamond armor?",
-      "description": "Look at a muffin with a spyglass",
-      "frame": "goal",
-      "show_toast": true,
-      "announce_to_chat": true,
-      "hidden": false
+  "display": {
+    "icon": {
+      "item": "minecraft:spyglass"
     },
-    "parent": "muffinhunt:spyglass_at_osfan",
-    "criteria": {
-      "spyglass_at_dragon": {
-        "trigger": "minecraft:using_item",
-        "conditions": {
-          "player": [
-            {
-              "condition": "minecraft:entity_properties",
-              "entity": "this",
-              "predicate": {
-                "player": {
-                  "looking_at": {
-                    "type": "minecraft:player",
-                    "team": "dragon_ender"
-                  }
+    "title": "Is it a speedrunner? In full diamond armor?",
+    "description": "Look at a muffin with a spyglass",
+    "frame": "goal",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false
+  },
+  "parent": "muffinhunt:spyglass_at_osfan",
+  "criteria": {
+    "spyglass_at_dragon": {
+      "trigger": "minecraft:using_item",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "player": {
+                "looking_at": {
+                  "type": "minecraft:player",
+                  "team": "dragon_ender"
                 }
               }
             }
-          ],
-          "item": {
-            "items": [
-              "minecraft:spyglass"
-            ]
           }
+        ],
+        "item": {
+          "items": [
+            "minecraft:spyglass"
+          ]
         }
       }
-    },
-    "rewards": {
-      "experience": 50
     }
+  },
+  "rewards": {
+    "experience": 50
   }
-  
+}

--- a/data/muffinhunt/advancements/spyglass_at_osfan.json
+++ b/data/muffinhunt/advancements/spyglass_at_osfan.json
@@ -1,44 +1,43 @@
 {
-    "display": {
-      "icon": {
-        "item": "minecraft:spyglass"
-      },
-      "title": "Is it a diamond zombie?",
-      "description": "Look at an osfan with a spyglass",
-      "frame": "goal",
-      "show_toast": true,
-      "announce_to_chat": true,
-      "hidden": false
+  "display": {
+    "icon": {
+      "item": "minecraft:spyglass"
     },
-    "parent": "minecraft:story/enter_the_end",
-    "criteria": {
-      "spyglass_at_dragon": {
-        "trigger": "minecraft:using_item",
-        "conditions": {
-          "player": [
-            {
-              "condition": "minecraft:entity_properties",
-              "entity": "this",
-              "predicate": {
-                "player": {
-                  "looking_at": {
-                    "type": "minecraft:player",
-                    "team": "juggernaut"
-                  }
+    "title": "Is it a diamond zombie?",
+    "description": "Look at an osfan with a spyglass",
+    "frame": "goal",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false
+  },
+  "parent": "minecraft:story/enter_the_end",
+  "criteria": {
+    "spyglass_at_dragon": {
+      "trigger": "minecraft:using_item",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "player": {
+                "looking_at": {
+                  "type": "minecraft:player",
+                  "team": "juggernaut"
                 }
               }
             }
-          ],
-          "item": {
-            "items": [
-              "minecraft:spyglass"
-            ]
           }
+        ],
+        "item": {
+          "items": [
+            "minecraft:spyglass"
+          ]
         }
       }
-    },
-    "rewards": {
-      "experience": 50
     }
+  },
+  "rewards": {
+    "experience": 50
   }
-  
+}

--- a/data/muffinhunt/advancements/take_aim.json
+++ b/data/muffinhunt/advancements/take_aim.json
@@ -1,36 +1,35 @@
 {
-    "display": {
-      "icon": {
-        "item": "minecraft:bow",
-        "nbt": "{Damage:0}"
-      },
-      "title": "Take Aim",
-      "description": "Shoot a player with a bow",
-      "frame": "task",
-      "show_toast": true,
-      "announce_to_chat": true,
-      "hidden": false
+  "display": {
+    "icon": {
+      "item": "minecraft:bow",
+      "nbt": "{Damage:0}"
     },
-    "parent": "muffinhunt:punch_muffin",
-    "criteria": {
-      "shot_arrow": {
-        "trigger": "minecraft:player_hurt_entity",
-        "conditions": {
-          "damage": {
-            "type": {
-              "is_projectile": true,
-              "direct_entity": {
-                "type": "#minecraft:arrows"
-              }
+    "title": "Take Aim",
+    "description": "Shoot a player with a bow",
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false
+  },
+  "parent": "muffinhunt:punch_muffin",
+  "criteria": {
+    "shot_arrow": {
+      "trigger": "minecraft:player_hurt_entity",
+      "conditions": {
+        "damage": {
+          "type": {
+            "is_projectile": true,
+            "direct_entity": {
+              "type": "#minecraft:arrows"
             }
           }
         }
       }
-    },
-    "requirements": [
-      [
-        "shot_arrow"
-      ]
+    }
+  },
+  "requirements": [
+    [
+      "shot_arrow"
     ]
-  }
-  
+  ]
+}

--- a/data/muffinhunt/loot_tables/entities/hoglin.json
+++ b/data/muffinhunt/loot_tables/entities/hoglin.json
@@ -1,38 +1,37 @@
 {
-    "type": "minecraft:entity",
-    "pools": [
-      {
-        "rolls": 2,
-        "entries": [
-          {
-            "type": "minecraft:item",
-            "weight": 2,
-            "name": "minecraft:air"
-          },
-          {
-            "type": "minecraft:item",
-            "weight": 1,
-            "name": "minecraft:cooked_porkchop",
-            "functions": [
-              {
-                "function": "minecraft:set_nbt",
-                "tag": "{CustomName:'[{\"text\":\"Voidchop\",\"color\":\"dark_purple\"}]'}"
-              }
-            ]
-          },
-          {
-            "type": "minecraft:item",
-            "weight": 1,
-            "name": "minecraft:cooked_porkchop",
-            "functions": [
-              {
-                "function": "minecraft:set_nbt",
-                "tag": "{CustomName:'[{\"text\":\"Voidchop\",\"color\":\"dark_purple\"}]'}"
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  }
-  
+  "type": "minecraft:entity",
+  "pools": [
+    {
+      "rolls": 2,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "weight": 2,
+          "name": "minecraft:air"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 1,
+          "name": "minecraft:cooked_porkchop",
+          "functions": [
+            {
+              "function": "minecraft:set_nbt",
+              "tag": "{CustomName:'[{\"text\":\"Voidchop\",\"color\":\"dark_purple\"}]'}"
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 1,
+          "name": "minecraft:cooked_porkchop",
+          "functions": [
+            {
+              "function": "minecraft:set_nbt",
+              "tag": "{CustomName:'[{\"text\":\"Voidchop\",\"color\":\"dark_purple\"}]'}"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/muffinhunt/tags/items/amethyst_items.json
+++ b/data/muffinhunt/tags/items/amethyst_items.json
@@ -1,12 +1,12 @@
 {
-    "replace": false,
-    "values": [
-      "minecraft:amethyst_shard",
-      "minecraft:amethyst_block",
-      "minecraft:small_amethyst_bud",
-      "minecraft:amethyst_cluster",
-      "minecraft:large_amethyst_bud",
-      "minecraft:medium_amethyst_bud",
-      "minecraft:budding_amethyst"
-    ]
-  }
+  "replace": false,
+  "values": [
+    "minecraft:amethyst_shard",
+    "minecraft:amethyst_block",
+    "minecraft:small_amethyst_bud",
+    "minecraft:amethyst_cluster",
+    "minecraft:large_amethyst_bud",
+    "minecraft:medium_amethyst_bud",
+    "minecraft:budding_amethyst"
+  ]
+}

--- a/data/muffinhunt/worldgen/noise_settings/end_with_caves.json
+++ b/data/muffinhunt/worldgen/noise_settings/end_with_caves.json
@@ -1,8 +1,6 @@
 {
   "sea_level": 0,
   "disable_mob_generation": true,
-  "noise_caves_enabled": true,
-  "noodle_caves_enabled": true,
   "aquifers_enabled": false,
   "ore_veins_enabled": true,
   "legacy_random_source": true,
@@ -45,13 +43,220 @@
       "Name": "minecraft:end_stone"
     }
   },
-  "structures": {
-    "structures": {
-      "minecraft:endcity": {
-        "spacing": 7,
-        "separation": 3,
-        "salt": 0
-      }
-    }
+  "noise_router": {
+    "final_density": {
+      "argument1": {
+        "argument": {
+          "argument1": 0.64,
+          "argument2": {
+            "argument": {
+              "argument": {
+                "argument": {
+                  "max_exclusive": 1.5625,
+                  "when_in_range": {
+                    "argument1": "minecraft:overworld/sloped_cheese",
+                    "argument2": {
+                      "argument1": 5,
+                      "argument2": "minecraft:overworld/caves/entrances",
+                      "type": "minecraft:mul"
+                    },
+                    "type": "minecraft:min"
+                  },
+                  "when_out_of_range": {
+                    "argument1": {
+                      "argument1": {
+                        "argument1": {
+                          "argument1": {
+                            "argument1": 4,
+                            "argument2": {
+                              "argument": {
+                                "noise": "minecraft:cave_layer",
+                                "xz_scale": 1,
+                                "y_scale": 8,
+                                "type": "minecraft:noise"
+                              },
+                              "type": "minecraft:square"
+                            },
+                            "type": "minecraft:mul"
+                          },
+                          "argument2": {
+                            "argument1": {
+                              "input": {
+                                "argument1": 0.27,
+                                "argument2": {
+                                  "noise": "minecraft:cave_cheese",
+                                  "xz_scale": 1,
+                                  "y_scale": 0.6666666666666666,
+                                  "type": "minecraft:noise"
+                                },
+                                "type": "minecraft:add"
+                              },
+                              "min": -1,
+                              "max": 1,
+                              "type": "minecraft:clamp"
+                            },
+                            "argument2": {
+                              "input": {
+                                "argument1": 1.5,
+                                "argument2": {
+                                  "argument1": -0.64,
+                                  "argument2": "minecraft:overworld/sloped_cheese",
+                                  "type": "minecraft:mul"
+                                },
+                                "type": "minecraft:add"
+                              },
+                              "min": 0,
+                              "max": 0.5,
+                              "type": "minecraft:clamp"
+                            },
+                            "type": "minecraft:add"
+                          },
+                          "type": "minecraft:add"
+                        },
+                        "argument2": "minecraft:overworld/caves/entrances",
+                        "type": "minecraft:min"
+                      },
+                      "argument2": {
+                        "argument1": "minecraft:overworld/caves/spaghetti_2d",
+                        "argument2": "minecraft:overworld/caves/spaghetti_roughness_function",
+                        "type": "minecraft:add"
+                      },
+                      "type": "minecraft:min"
+                    },
+                    "argument2": {
+                      "max_exclusive": 0.03,
+                      "when_in_range": -1000000,
+                      "when_out_of_range": "minecraft:overworld/caves/pillars",
+                      "input": "minecraft:overworld/caves/pillars",
+                      "min_inclusive": -1000000,
+                      "type": "minecraft:range_choice"
+                    },
+                    "type": "minecraft:max"
+                  },
+                  "input": "minecraft:overworld/sloped_cheese",
+                  "min_inclusive": -1000000,
+                  "type": "minecraft:range_choice"
+                },
+                "type": "minecraft:slide"
+              },
+              "type": "minecraft:blend_density"
+            },
+            "type": "minecraft:interpolated"
+          },
+          "type": "minecraft:mul"
+        },
+        "type": "minecraft:squeeze"
+      },
+      "argument2": "minecraft:overworld/caves/noodle",
+      "type": "minecraft:min"
+    },
+    "vein_toggle": {
+      "argument": {
+        "max_exclusive": 51,
+        "when_in_range": {
+          "noise": "minecraft:ore_veininess",
+          "xz_scale": 1.5,
+          "y_scale": 1.5,
+          "type": "minecraft:noise"
+        },
+        "when_out_of_range": 0,
+        "input": "minecraft:y",
+        "min_inclusive": -60,
+        "type": "minecraft:range_choice"
+      },
+      "type": "minecraft:interpolated"
+    },
+    "vein_ridged": {
+      "argument1": -0.07999999821186066,
+      "argument2": {
+        "argument1": {
+          "argument": {
+            "argument": {
+              "max_exclusive": 51,
+              "when_in_range": {
+                "noise": "minecraft:ore_vein_a",
+                "xz_scale": 4,
+                "y_scale": 4,
+                "type": "minecraft:noise"
+              },
+              "when_out_of_range": 0,
+              "input": "minecraft:y",
+              "min_inclusive": -60,
+              "type": "minecraft:range_choice"
+            },
+            "type": "minecraft:interpolated"
+          },
+          "type": "minecraft:abs"
+        },
+        "argument2": {
+          "argument": {
+            "argument": {
+              "max_exclusive": 51,
+              "when_in_range": {
+                "noise": "minecraft:ore_vein_b",
+                "xz_scale": 4,
+                "y_scale": 4,
+                "type": "minecraft:noise"
+              },
+              "when_out_of_range": 0,
+              "input": "minecraft:y",
+              "min_inclusive": -60,
+              "type": "minecraft:range_choice"
+            },
+            "type": "minecraft:interpolated"
+          },
+          "type": "minecraft:abs"
+        },
+        "type": "minecraft:max"
+      },
+      "type": "minecraft:add"
+    },
+    "vein_gap": {
+      "noise": "minecraft:ore_gap",
+      "xz_scale": 1,
+      "y_scale": 1,
+      "type": "minecraft:noise"
+    },
+    "erosion": "minecraft:overworld/erosion",
+    "depth": "minecraft:overworld/depth",
+    "ridges": "minecraft:overworld/ridges",
+    "initial_density_without_jaggedness": {
+      "argument1": 4,
+      "argument2": {
+        "argument": {
+          "argument1": "minecraft:overworld/depth",
+          "argument2": {
+            "argument": "minecraft:overworld/factor",
+            "type": "minecraft:cache_2d"
+          },
+          "type": "minecraft:mul"
+        },
+        "type": "minecraft:quarter_negative"
+      },
+      "type": "minecraft:mul"
+    },
+    "lava": 0,
+    "temperature": {
+      "xz_scale": 0.25,
+      "y_scale": 0,
+      "noise": "minecraft:temperature",
+      "shift_x": "minecraft:shift_x",
+      "shift_y": 0,
+      "shift_z": "minecraft:shift_z",
+      "type": "minecraft:shifted_noise"
+    },
+    "vegetation": {
+      "xz_scale": 0.25,
+      "y_scale": 0,
+      "noise": "minecraft:vegetation",
+      "shift_x": "minecraft:shift_x",
+      "shift_y": 0,
+      "shift_z": "minecraft:shift_z",
+      "type": "minecraft:shifted_noise"
+    },
+    "continents": "minecraft:overworld/continents",
+    "barrier": 0,
+    "fluid_level_floodedness": 0,
+    "fluid_level_spread": 0
   }
 }


### PR DESCRIPTION
## Purpose
Fix 1.18.2 compatibilty, for the third time...Third time's the charm!

## Approach
Use misode's datapack upgrader (Thanks @misode!)

## Future work
This *should* cover everything for 1.18.2, so we shouldn't have more work to do (we hope). 

#### Checklist
- [ ] Included tests
- [ ] Updated documentation in [README](https://github.com/osfanbuff63/muffinhunt-datapack/blob/master/README.md) and/or [docs folder](/docs)
- [ ] Tested in the latest version of Minecraft


