### PR TITLE
Fix armor stand not glowing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-# Normalize text
+# Normalize text to LF
 * text=auto
 
 *.off linguist-language=yaml

--- a/data/muffinhunt/functions/dev/force_end_muffinhunt.mcfunction
+++ b/data/muffinhunt/functions/dev/force_end_muffinhunt.mcfunction
@@ -11,3 +11,4 @@ tag @a[tag=muffinhunt_nether] remove muffinhunt_nether
 tag @a[tag=MHend] remove MHend
 tag @a[tag=muffinhunt_surface_overworld] remove muffinhunt_surface_overworld 
 scoreboard players set MuffinHunt MuffinHunt 0
+kill @e[tag=MHendPort]

--- a/data/muffinhunt/functions/end_muffinhunt_dragon_ender_win.mcfunction
+++ b/data/muffinhunt/functions/end_muffinhunt_dragon_ender_win.mcfunction
@@ -11,3 +11,4 @@ tag @a[tag=MHend] remove MHend
 tag @a[tag=muffinhunt_surface_overworld] remove muffinhunt_surface_overworld
 tag @a[tag=muffinhunt_nether] remove muffinhunt_nether
 scoreboard players set MuffinHunt MuffinHunt 0
+kill @e[tag=MHendPort]

--- a/data/muffinhunt/functions/end_muffinhunt_juggernaut_win.mcfunction
+++ b/data/muffinhunt/functions/end_muffinhunt_juggernaut_win.mcfunction
@@ -12,3 +12,4 @@ tag @a[tag=MHend] remove MHend
 tag @a[tag=muffinhunt_surface_overworld] remove muffinhunt_surface_overworld
 tag @a[tag=muffinhunt_nether] remove muffinhunt_nether
 scoreboard players set MuffinHunt MuffinHunt 0
+kill @e[tag=MHendPort]

--- a/data/muffinhunt/functions/start_muffinhunt.mcfunction
+++ b/data/muffinhunt/functions/start_muffinhunt.mcfunction
@@ -49,7 +49,9 @@ scoreboard players set MuffinHuntLive4 MuffinHuntRunnerLives 2
 scoreboard players set MuffinHuntLive3 MuffinHuntRunnerLives 3
 scoreboard players set MuffinHuntLive5 MuffinHuntRunnerLives 1
 execute as @a[tag=muffinhunt] at @s run spawnpoint @s ~ ~ ~ 
-execute at @a[tag=muffinhunt,sort=random,limit=1] run summon armor_stand ~ ~ ~ {CustomName:'[{"text":"End Portal","color":"light_purple"}]',CustomNameVisible:1}
+team add portal
+team modify portal color light_purple
+execute at @a[tag=muffinhunt,sort=random,limit=1] run summon armor_stand ~ ~ ~ {CustomName:'[{"text":"End Portal","color":"light_purple"}]',CustomNameVisible:1,Glowing:1b,Team:"portal",Invisible:1}
 tellraw @a ["",{"text":"Overworld ","color":"green"},{"text":"items given! ","color":"gold"},{"text":"Juggernaut(s)","color":"dark_aqua"},{"text":", please begin tracking the ","color":"gold"},{"text":"Dragon Ender","color":"dark_purple"},{"text":"! Once that is complete, the ","color":"gold"},{"text":"Muffin","color":"yellow"},{"text":"Hunt ","color":"dark_aqua"},{"text":"can begin once the ","color":"gold"},{"text":"Dragon Ender ","color":"dark_purple"},{"text":"hits the ","color":"gold"},{"text":"Juggernaut(s)","color":"dark_aqua"},{"text":"!","color":"gold"}]
 # See #101
 tag @a[tag=muffinhunt,tag=MHstart] remove MHstart 

--- a/data/muffinhunt/functions/start_muffinhunt.mcfunction
+++ b/data/muffinhunt/functions/start_muffinhunt.mcfunction
@@ -51,7 +51,7 @@ scoreboard players set MuffinHuntLive5 MuffinHuntRunnerLives 1
 execute as @a[tag=muffinhunt] at @s run spawnpoint @s ~ ~ ~ 
 team add portal
 team modify portal color light_purple
-execute at @a[tag=muffinhunt,sort=random,limit=1] run summon armor_stand ~ ~ ~ {CustomName:'[{"text":"End Portal","color":"light_purple"}]',CustomNameVisible:1,Glowing:1b,Team:"portal",Invisible:1}
+execute at @a[tag=muffinhunt,sort=random,limit=1] run summon armor_stand ~ ~ ~ {CustomName:'[{"text":"End Portal","color":"light_purple"}]',CustomNameVisible:1,Glowing:1b,Team:"portal",Invisible:1,Tags:["MHendPort"]}
 tellraw @a ["",{"text":"Overworld ","color":"green"},{"text":"items given! ","color":"gold"},{"text":"Juggernaut(s)","color":"dark_aqua"},{"text":", please begin tracking the ","color":"gold"},{"text":"Dragon Ender","color":"dark_purple"},{"text":"! Once that is complete, the ","color":"gold"},{"text":"Muffin","color":"yellow"},{"text":"Hunt ","color":"dark_aqua"},{"text":"can begin once the ","color":"gold"},{"text":"Dragon Ender ","color":"dark_purple"},{"text":"hits the ","color":"gold"},{"text":"Juggernaut(s)","color":"dark_aqua"},{"text":"!","color":"gold"}]
 # See #101
 tag @a[tag=muffinhunt,tag=MHstart] remove MHstart 


### PR DESCRIPTION
## Issue fixed
Fixes an issue where the armor stand would not glow, and not purple when given glowing.

## Approach
Adds a `portal` team to make glow color purple, and summons the armor stand with `Glowing:1b` NBT tag

## Future work
None

#### Checklist
- [x] Included tests
- [x] Tested in the latest release version of Minecraft
- [ ] Tested in the latest snapshot version of Minecraft 

